### PR TITLE
Potential fix for code scanning alert no. 17: Client-side cross-site scripting

### DIFF
--- a/Chapter04/websocket-server/public/index.html
+++ b/Chapter04/websocket-server/public/index.html
@@ -12,8 +12,18 @@
         output.innerHTML += log('Sent', msg);
     });
 
+    // Helper to escape HTML special chars to prevent XSS
+    function escapeHTML(str) {
+        return String(str)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+
     function log(event, msg) {
-        return '<p>' + event + ': ' + msg + '</p>';
+        return '<p>' + escapeHTML(event) + ': ' + escapeHTML(msg) + '</p>';
     }
 
     ws.onmessage = function (e) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/17](https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/17)

To prevent DOM-based (client-side) XSS, you should always escape or sanitize any untrusted value before injecting it into the page with `innerHTML`, *especially* when the data comes from external sources like a WebSocket message. The best fix is to replace the direct string concatenation with one of two approaches:

1. **Escape all HTML special characters in the untrusted data:** Write or use a small utility function to replace `"&"`, `"<"`, `">"`, `'"'`, and `"'` with their respective HTML entities, and use this function to process all dynamic values before inserting them into the DOM.
2. **Use DOM APIs instead of setting `innerHTML`:** Construct the elements using `document.createElement` and append text using `textContent` to ensure the browser treats user-provided data as text and not as HTML.

For the provided code, the cleanest fix (requiring minimal changes) is to add an `escapeHTML()` function and use it for all untrusted values (`msg` and possibly `event` if it is ever user-controlled).

You should:
- Add an `escapeHTML` helper in your `<script>` block.
- Use it in the `log()` function for the `msg` argument (and for `event` as defense-in-depth).
- Only escape `event` if you think it could be manipulated; at least, escape `msg`.

Only modify the code in `Chapter04/websocket-server/public/index.html`, inside the shown code snippets.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
