### PR TITLE
Potential fix for code scanning alert no. 5: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter09/express-csrf/csurf-server.js
+++ b/Chapter09/express-csrf/csurf-server.js
@@ -18,7 +18,7 @@ app.use(
     name: 'SESSIONID',
     resave: false,
     saveUninitialized: false,
-    cookie: { sameSite: true }
+    cookie: { sameSite: true, secure: true }
   })
 );
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/5](https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/5)

The best fix is to set the `secure` attribute to `true` in the `cookie` configuration for `express-session`:  
```js
cookie: { sameSite: true, secure: true }
```
This ensures that the session cookie (`SESSIONID`) will only be sent over HTTPS connections. However, when developing locally (without HTTPS), this may cause issues with the session not being set or transmitted; in production, `secure: true` absolutely should be set for sensitive cookies. The edit should be made on the session configuration block, at the `cookie:` object (line 21).

No new methods or imports are required, just an in-place edit to the `cookie` options.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
