### PR TITLE
Potential fix for code scanning alert no. 6: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter09/express-csrf/server.js
+++ b/Chapter09/express-csrf/server.js
@@ -14,7 +14,11 @@ app.use(
     secret: 'Node Cookbook',
     name: 'SESSIONID',
     resave: false,
-    saveUninitialized: false
+    saveUninitialized: false,
+    cookie: {
+      secure: true,
+      httpOnly: true
+    }
   })
 );
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/6](https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/6)

To fix this clear text transmission of a sensitive cookie, explicitly set the `secure` attribute on the session cookie within the `express-session` middleware configuration. This can be done by adding a `cookie` object to the session configuration, setting `secure: true`. 

For full compatibility, the cookie should ideally also have the `httpOnly` flag to prevent JavaScript access. In environments where HTTPS is not available (such as local development), setting `secure: true` will cause cookies to be dropped. The best solution is to enable the `secure` flag unconditionally for security, or optionally add an environment-based conditional, though for minimal change, just add the `cookie: { secure: true, httpOnly: true }` block in the session options.

Edit the initialization of the `session` middleware in `Chapter09/express-csrf/server.js`, specifically lines 13-18, to include the `cookie` attribute as shown below. No additional imports or package installs are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
