### PR TITLE
Potential fix for code scanning alert no. 7: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter09/express-csrf/fixed-server.js
+++ b/Chapter09/express-csrf/fixed-server.js
@@ -16,7 +16,7 @@ app.use(
     name: 'SESSIONID',
     resave: false,
     saveUninitialized: false,
-    cookie: { sameSite: true }
+    cookie: { sameSite: true, secure: true }
   })
 );
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/7](https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/7)

**General fix:**  
To prevent session cookies from being exposed over clear text, add the `secure: true` attribute to the session's `cookie` options in the express-session configuration. This ensures cookies are only sent over HTTPS connections.

**Detailed steps:**  
- In `Chapter09/express-csrf/fixed-server.js`, in the object passed to `session()`, change the `cookie` entry so that it includes `secure: true` in addition to other existing attributes (like `sameSite: true`).
- Optionally, to avoid development breakage (since dev servers often use HTTP), set `secure: true` when running in production, e.g. `secure: process.env.NODE_ENV === "production"`.

**What is needed:**  
- Update the `cookie` property in the options object passed to session middleware.
- No new imports or definitions required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
