### PR TITLE
Potential fix for code scanning alert no. 2: Missing CSRF middleware

### DIFF
--- a/Chapter09/express-csrf/csurf-server.js
+++ b/Chapter09/express-csrf/csurf-server.js
@@ -24,11 +24,12 @@ app.use(
 
 app.use(bodyParser.urlencoded({ extended: false }));
 
-app.get('/', (req, res) => {
+app.get('/', csrf, (req, res) => {
   if (req.session.user) return res.redirect('/account');
   res.send(`
     <h1>Social Media Account - Login</h1>
     <form method="POST" action="/">
+      <input type="hidden" name="_csrf" value="${req.csrfToken()}">
       <label> Username <input name=username> </label>
       <label> Password <input name=password type=password> </label>
       <input type=submit>
@@ -36,7 +37,7 @@ app.get('/', (req, res) => {
   `);
 });
 
-app.post('/', (req, res) => {
+app.post('/', csrf, (req, res) => {
   if (
     req.body.username === mockUser.username &&
     req.body.password === mockUser.password


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/2](https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/2)

To fix the missing CSRF protection, add the CSRF middleware to the login endpoint. Specifically, include the `csrf` middleware on the route for `GET /` (to generate a CSRF token for the login form) and on the `POST /` route (to validate the token submission). You'll also need to provide the CSRF token as a hidden input in the login HTML form, mirroring the defense tactic used in the `/account` route where the token is injected. No additional libraries or custom methods are required, only correct usage of the already-imported `csurf` middleware. The changes should be made in the `Chapter09/express-csrf/csurf-server.js` file, with minor adjustments to inject the CSRF token on the login page and validate it on submission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
