### PR TITLE
Potential fix for code scanning alert no. 4: Missing CSRF middleware

### DIFF
--- a/Chapter09/express-csrf/fixed-server.js
+++ b/Chapter09/express-csrf/fixed-server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const session = require('express-session');
 const escape = require('escape-html');
+const lusca = require('lusca');
 const app = express();
 
 const mockUser = {
@@ -21,12 +22,14 @@ app.use(
 );
 
 app.use(bodyParser.urlencoded({ extended: false }));
+app.use(lusca.csrf());
 
 app.get('/', (req, res) => {
   if (req.session.user) return res.redirect('/account');
   res.send(`
     <h1>Social Media Account - Login</h1>
     <form method="POST" action="/">
+      <input type="hidden" name="_csrf" value="${escape(req.csrfToken())}">
       <label> Username <input name=username> </label>
       <label> Password <input name=password type=password> </label>
       <input type=submit>
@@ -45,6 +48,7 @@ app.post('/', (req, res) => {
   else res.redirect('/');
 });
 
+        <input type="hidden" name="_csrf" value="${escape(req.csrfToken())}">
 app.get('/account', (req, res) => {
   if (!req.session.user) return res.redirect('/');
   res.send(`

--- a/Chapter09/express-csrf/package.json
+++ b/Chapter09/express-csrf/package.json
@@ -4,6 +4,7 @@
     "csurf": "^1.10.0",
     "express": "^4.21.2",
     "express-session": "^1.18.2",
-    "escape-html": "^1.0.3"
+    "escape-html": "^1.0.3",
+    "lusca": "^1.7.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/4](https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/4)

To fix the issue, we should add CSRF protection middleware to the Express app. This can be done by introducing a well-known CSRF middleware like `lusca`, as recommended. The fix involves:

- Importing `lusca`
- Adding csurf protection globally, after the session and bodyParser middlewares.
- Updating the HTML forms to use the CSRF token by embedding it as a hidden input field. The CSRF token can be accessed in routes via `req.csrfToken()` when using `lusca`.
  
Specifically, in `Chapter09/express-csrf/fixed-server.js`, do the following:
- Add `const lusca = require('lusca');` to imports.
- Insert `app.use(lusca.csrf());` after session and bodyParser middlewares.
- In GET /, update the login form to include a hidden CSRF token input.
- In GET /account, update the email update form to include a hidden CSRF token input.

Since `lusca.csrf()` populates `req.csrfToken()`, you can use it within the route handlers to inject the token value into the forms.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
