### PR TITLE
Potential fix for code scanning alert no. 20: Missing CSRF middleware

### DIFF
--- a/Chapter09/express-csrf/server.js
+++ b/Chapter09/express-csrf/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const session = require('express-session');
+const lusca = require('lusca');
 const app = express();
 
 const mockUser = {
@@ -23,12 +24,14 @@ app.use(
 );
 
 app.use(bodyParser.urlencoded({ extended: false }));
+app.use(lusca.csrf());
 
 app.get('/', (req, res) => {
   if (req.session.user) return res.redirect('/account');
   res.send(`
     <h1>Social Media Account - Login</h1>
     <form method="POST" action="/">
+      <input type="hidden" name="_csrf" value="${req.csrfToken()}">
       <label> Username <input name=username> </label>
       <label> Password <input name=password type=password> </label>
       <input type=submit>
@@ -47,6 +50,7 @@ app.post('/', (req, res) => {
   else res.redirect('/');
 });
 
+        <input type="hidden" name="_csrf" value="${req.csrfToken()}">
 app.get('/account', (req, res) => {
   if (!req.session.user) return res.redirect('/');
   res.send(`


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/20](https://github.com/ibiscum/Node.js-Cookbook-Fifth-Edition/security/code-scanning/20)

To fix this problem, we need to add middleware to defend against CSRF attacks. The best practice in Express is to use established middleware such as `lusca` or `csurf`. Among these, CodeQL's own example recommends `lusca.csrf`. We must:

1. Install `lusca` (which exposes a `.csrf()` middleware function).
2. Require `lusca` in the code.
3. After `express-session` and just before registering routes, add a middleware registration: `app.use(lusca.csrf());`
4. In each form rendered by the server that performs a state-changing action via POST, add a hidden field containing the CSRF token. With `lusca`, the token is available on `req.csrfToken()` (which must be called inside the route handler and not middleware).
5. In this code, a POST route `/update` updates user data via a form rendered at `/account`. So `/account`'s form will need a hidden CSRF token input field, using a value from `req.csrfToken()`. 
6. Also, adapt `/` (login) form to include the CSRF token, since it's also a POST route.
7. Adjust the code so `res.send()` for the forms interpolates `req.csrfToken()` correctly. Since these are inline template strings, we must ensure that token is provided.

Modified regions are:
- Add the `lusca` import.
- Add `app.use(lusca.csrf());` after `session` and before any routes.
- Update the `/account` and `/` GET handlers so that their forms include a CSRF token from `req.csrfToken()`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
